### PR TITLE
Use Jenkinsfile library v2 to free some node usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
-@Library('SonarSource@1.12') _
+@Library('SonarSource@2.0') _
 
 pipeline {
-  agent {
-    label 'linux'
-  }
+  agent none
   parameters {
     string(name: 'GIT_SHA1', description: 'Git SHA1 (provided by travisci hook job)')
     string(name: 'CI_BUILD_NAME', defaultValue: 'sonar-auth-saml', description: 'Build Name (provided by travisci hook job)')


### PR DESCRIPTION
The aim of the new version of the library is to send any notifications to BURGR, GitHub and Repox without requiring a slave.
With this, we can then free up the usage of some slaves.