### PR TITLE
SQAUTHSAML-9 Don't append a / to the login URL

### DIFF
--- a/sonar-auth-saml-plugin/src/main/java/org/sonarsource/auth/saml/SamlSettings.java
+++ b/sonar-auth-saml-plugin/src/main/java/org/sonarsource/auth/saml/SamlSettings.java
@@ -69,7 +69,7 @@ public class SamlSettings {
   }
 
   String getLoginUrl() {
-    return urlWithEndingSlash(configuration.get(LOGIN_URL).orElseThrow(() -> new IllegalArgumentException("Login URL is missing")));
+    return configuration.get(LOGIN_URL).orElseThrow(() -> new IllegalArgumentException("Login URL is missing"));
   }
 
   String getCertificate() {
@@ -100,14 +100,6 @@ public class SamlSettings {
       configuration.get(CERTIFICATE).isPresent() &&
       configuration.get(USER_LOGIN_ATTRIBUTE).isPresent() &&
       configuration.get(USER_NAME_ATTRIBUTE).isPresent();
-  }
-
-  @CheckForNull
-  private static String urlWithEndingSlash(@Nullable String url) {
-    if (url != null && !url.endsWith("/")) {
-      return url + "/";
-    }
-    return url;
   }
 
   static List<PropertyDefinition> definitions() {

--- a/sonar-auth-saml-plugin/src/test/java/org/sonarsource/auth/saml/SamlSettingsTest.java
+++ b/sonar-auth-saml-plugin/src/test/java/org/sonarsource/auth/saml/SamlSettingsTest.java
@@ -78,7 +78,7 @@ public class SamlSettingsTest {
     assertThat(underTest.getLoginUrl()).isEqualTo("http://localhost:8080/");
 
     settings.setProperty("sonar.auth.saml.loginUrl", "http://localhost:8080");
-    assertThat(underTest.getLoginUrl()).isEqualTo("http://localhost:8080/");
+    assertThat(underTest.getLoginUrl()).isEqualTo("http://localhost:8080");
   }
 
   @Test


### PR DESCRIPTION
Some IDPs SingleSignOnService URL doesn't have a / at the end, e.g. the
SAML2 reference implementation Shibboleth.